### PR TITLE
feat: support Python 3.12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nodejs (18.19.1+dfsg-3deepin1) unstable; urgency=medium
+
+  * support python3.12.
+
+ -- lichenggang <lichenggang@deepin.org>  Fri, 22 Aug 2025 16:00:05 +0800
+
 nodejs (18.19.1+dfsg-3) unstable; urgency=medium
 
   * mips64el: skip failing test

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -30,3 +30,4 @@ build/test_runner_escape_path.patch
 build/test_dns_resolveany_bad_ancount.patch
 loong64/tests.patch
 deps/v8-no-static-zlib.patch
+support-python3.12.patch

--- a/debian/patches/support-python3.12.patch
+++ b/debian/patches/support-python3.12.patch
@@ -1,0 +1,22 @@
+Description: <build: support Python 3.12>
+ https://github.com/nodejs/node/commit/a709a7e0c5461583f0f8a0dc2e92e3698e8fc2da
+
+--- nodejs-18.19.1+dfsg.orig/configure
++++ nodejs-18.19.1+dfsg/configure
+@@ -4,6 +4,7 @@
+ # Note that the mix of single and double quotes is intentional,
+ # as is the fact that the ] goes on a new line.
+ _=[ 'exec' '/bin/sh' '-c' '''
++command -v python3.12 >/dev/null && exec python3.12 "$0" "$@"
+ command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
+ command -v python3.10 >/dev/null && exec python3.10 "$0" "$@"
+ command -v python3.9 >/dev/null && exec python3.9 "$0" "$@"
+@@ -23,7 +24,7 @@ except ImportError:
+   from distutils.spawn import find_executable as which
+ 
+ print('Node.js configure: Found Python {}.{}.{}...'.format(*sys.version_info))
+-acceptable_pythons = ((3, 11), (3, 10), (3, 9), (3, 8), (3, 7), (3, 6))
++acceptable_pythons = ((3, 12), (3, 11), (3, 10), (3, 9), (3, 8), (3, 7), (3, 6))
+ if sys.version_info[:2] in acceptable_pythons:
+   import configure
+ else:


### PR DESCRIPTION
## Summary by Sourcery

Add support for Python 3.12 in Debian packaging by including a new patch, updating the patch series, and bumping the changelog.

New Features:
- Support Python 3.12

Chores:
- Add debian/patches/support-python3.12.patch and update debian/patches/series
- Update debian/changelog for the new Python version support